### PR TITLE
Migrate UA to GA4 tag for Google Analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,14 +2,14 @@
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en">
 
 <head>
-<!-- Global site tag (gtag.js) - Google Analytics -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-112765193-1"></script>
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-94XS2SB0TX"></script>
 <script>
   window.dataLayer = window.dataLayer || [];
   function gtag(){dataLayer.push(arguments);}
   gtag('js', new Date());
 
-  gtag('config', 'UA-112765193-1');
+  gtag('config', 'G-94XS2SB0TX');
 </script>
 
 <meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1" />


### PR DESCRIPTION
The Universal Analytics property will stop processing data on July 1,
2023. Thus we migrate to GA4 property.

Migration guide
https://support.google.com/analytics/answer/10759417?hl=en was followed for the setup.